### PR TITLE
Replaced dls-controls with DiamondLightSource

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Build Status](https://api.travis-ci.org/dls-controls/PMAC-Trajectory-Scans.svg)](https://travis-ci.org/dls-controls/PMAC-Trajectory-Scans)
-[![Coverage Status](https://coveralls.io/repos/github/dls-controls/PMAC-Trajectory-Scans/badge.svg?branch=master)](https://coveralls.io/github/dls-controls/PMAC-Trajectory-Scans?branch=master)
-[![Code Health](https://landscape.io/github/dls-controls/PMAC-Trajectory-Scans/master/landscape.svg?style=flat)](https://landscape.io/github/dls-controls/PMAC-Trajectory-Scans/master)
+[![Build Status](https://api.travis-ci.org/DiamondLightSource/PMAC-Trajectory-Scans.svg)](https://travis-ci.org/DiamondLightSource/PMAC-Trajectory-Scans)
+[![Coverage Status](https://coveralls.io/repos/github/DiamondLightSource/PMAC-Trajectory-Scans/badge.svg?branch=master)](https://coveralls.io/github/DiamondLightSource/PMAC-Trajectory-Scans?branch=master)
+[![Code Health](https://landscape.io/github/DiamondLightSource/PMAC-Trajectory-Scans/master/landscape.svg?style=flat)](https://landscape.io/github/DiamondLightSource/PMAC-Trajectory-Scans/master)
 [![ReadTheDocs](https://readthedocs.org/projects/pmac-trajectory-scans/badge/?version=latest)](http://pmac-trajectory-scans.readthedocs.org)
 
 # PMAC-Trajectory-Scans


### PR DESCRIPTION
Repository was automatically transferred from `dls-controls/PMAC-Trajectory-Scans` using https://gitlab.diamond.ac.uk/github/github-scripts